### PR TITLE
Enhanced LLM-related feature testing.

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -54,6 +54,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -3337,6 +3338,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -3974,6 +3976,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4320,6 +4323,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -4970,6 +4974,7 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",

--- a/backend/tests/architectureAPI.test.js
+++ b/backend/tests/architectureAPI.test.js
@@ -1,0 +1,343 @@
+import { jest } from '@jest/globals';
+import request from 'supertest';
+import express from 'express';
+import { createArchitectureRouter } from '../src/routes/architectureAPI.js';
+import { UserInputError } from '../src/services/architectureService.js';
+
+describe('Architecture API', () => {
+  let app;
+  let mockService;
+
+  const mockResult = {
+    diagram: 'graph TD\nA-->B',
+    metadata: {
+      owner: 'test',
+      repo: 'repo',
+      repoUrl: 'https://github.com/test/repo',
+      branch: 'main',
+      llm: { provider: 'openai' }
+    },
+    rawLlmResponse: {},
+    prompt: 'test prompt',
+    systemPrompt: 'test system prompt'
+  };
+
+  beforeEach(() => {
+    // Create mock service
+    mockService = {
+      generateArchitectureDiagram: jest.fn()
+    };
+
+    // Setup Express app with the router
+    app = express();
+    app.use(express.json());
+    app.use(createArchitectureRouter(mockService));
+
+    // Default successful response
+    mockService.generateArchitectureDiagram.mockResolvedValue(mockResult);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('POST /api/architecture', () => {
+    test('should generate diagram with valid request body', async () => {
+      const response = await request(app)
+        .post('/api/architecture')
+        .send({
+          repoUrl: 'https://github.com/test/repo',
+          branch: 'main'
+        });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toHaveProperty('success', true);
+      expect(response.body).toHaveProperty('diagram', 'graph TD\nA-->B');
+      expect(response.body).toHaveProperty('metadata');
+      expect(response.body.metadata).toHaveProperty('llm');
+    });
+
+    test('should call service with correct parameters', async () => {
+      await request(app)
+        .post('/api/architecture')
+        .send({
+          repoUrl: 'https://github.com/facebook/react',
+          branch: 'main'
+        });
+
+      expect(mockService.generateArchitectureDiagram).toHaveBeenCalledWith({
+        repoUrl: 'https://github.com/facebook/react',
+        branch: 'main'
+      });
+    });
+
+    test('should handle request without branch parameter', async () => {
+      await request(app)
+        .post('/api/architecture')
+        .send({
+          repoUrl: 'https://github.com/test/repo'
+        });
+
+      expect(mockService.generateArchitectureDiagram).toHaveBeenCalledWith({
+        repoUrl: 'https://github.com/test/repo',
+        branch: undefined
+      });
+    });
+
+    test('should return 400 if repoUrl is missing', async () => {
+      const response = await request(app)
+        .post('/api/architecture')
+        .send({
+          branch: 'main'
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body).toHaveProperty('success', false);
+      expect(response.body).toHaveProperty('error', 'The "repoUrl" parameter is required.');
+    });
+
+    test('should return 400 if repoUrl is empty string', async () => {
+      const response = await request(app)
+        .post('/api/architecture')
+        .send({
+          repoUrl: ''
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body).toHaveProperty('success', false);
+      expect(response.body).toHaveProperty('error', 'The "repoUrl" parameter is required.');
+    });
+
+    test('should handle UserInputError from service', async () => {
+      mockService.generateArchitectureDiagram.mockRejectedValue(
+        new UserInputError('Invalid repository URL')
+      );
+
+      const response = await request(app)
+        .post('/api/architecture')
+        .send({
+          repoUrl: 'invalid-url'
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body).toHaveProperty('success', false);
+      expect(response.body).toHaveProperty('error', 'Invalid repository URL');
+    });
+
+    test('should handle service errors with statusCode', async () => {
+      const error = new Error('Repository not found');
+      error.statusCode = 404;
+      mockService.generateArchitectureDiagram.mockRejectedValue(error);
+
+      const response = await request(app)
+        .post('/api/architecture')
+        .send({
+          repoUrl: 'https://github.com/test/nonexistent'
+        });
+
+      expect(response.status).toBe(404);
+      expect(response.body).toHaveProperty('success', false);
+      expect(response.body).toHaveProperty('error', 'Repository not found');
+    });
+
+    test('should return 500 for unknown errors', async () => {
+      mockService.generateArchitectureDiagram.mockRejectedValue(
+        new Error('Unexpected error')
+      );
+
+      const response = await request(app)
+        .post('/api/architecture')
+        .send({
+          repoUrl: 'https://github.com/test/repo'
+        });
+
+      expect(response.status).toBe(500);
+      expect(response.body).toHaveProperty('success', false);
+      expect(response.body).toHaveProperty('error', 'Unexpected error');
+    });
+
+    test('should handle malformed JSON', async () => {
+      const response = await request(app)
+        .post('/api/architecture')
+        .set('Content-Type', 'application/json')
+        .send('{ invalid json }');
+
+      expect(response.status).toBeGreaterThanOrEqual(400);
+    });
+  });
+
+  describe('GET /api/architecture', () => {
+    test('should generate diagram with query parameters', async () => {
+      const response = await request(app)
+        .get('/api/architecture')
+        .query({
+          repoUrl: 'https://github.com/test/repo',
+          branch: 'main'
+        });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toHaveProperty('success', true);
+      expect(response.body).toHaveProperty('diagram');
+      expect(response.body).toHaveProperty('metadata');
+    });
+
+    test('should call service with correct parameters', async () => {
+      await request(app)
+        .get('/api/architecture')
+        .query({
+          repoUrl: 'https://github.com/expressjs/express',
+          branch: 'master'
+        });
+
+      expect(mockService.generateArchitectureDiagram).toHaveBeenCalledWith({
+        repoUrl: 'https://github.com/expressjs/express',
+        branch: 'master'
+      });
+    });
+
+    test('should handle request without branch parameter', async () => {
+      await request(app)
+        .get('/api/architecture')
+        .query({
+          repoUrl: 'https://github.com/test/repo'
+        });
+
+      expect(mockService.generateArchitectureDiagram).toHaveBeenCalledWith({
+        repoUrl: 'https://github.com/test/repo',
+        branch: undefined
+      });
+    });
+
+    test('should return 400 if repoUrl is missing', async () => {
+      const response = await request(app)
+        .get('/api/architecture')
+        .query({
+          branch: 'main'
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body).toHaveProperty('success', false);
+      expect(response.body).toHaveProperty('error', 'The "repoUrl" parameter is required.');
+    });
+
+    test('should handle service errors', async () => {
+      mockService.generateArchitectureDiagram.mockRejectedValue(
+        new Error('Service error')
+      );
+
+      const response = await request(app)
+        .get('/api/architecture')
+        .query({
+          repoUrl: 'https://github.com/test/repo'
+        });
+
+      expect(response.status).toBe(500);
+      expect(response.body).toHaveProperty('success', false);
+    });
+
+    test('should handle URL-encoded special characters', async () => {
+      const repoUrl = 'https://github.com/test/repo-with-special-chars';
+      
+      await request(app)
+        .get('/api/architecture')
+        .query({ repoUrl });
+
+      expect(mockService.generateArchitectureDiagram).toHaveBeenCalledWith({
+        repoUrl,
+        branch: undefined
+      });
+    });
+  });
+
+  describe('Request Parameter Priority', () => {
+    test('should prefer body parameters over query parameters for POST', async () => {
+      await request(app)
+        .post('/api/architecture')
+        .query({
+          repoUrl: 'https://github.com/query/repo',
+          branch: 'query-branch'
+        })
+        .send({
+          repoUrl: 'https://github.com/body/repo',
+          branch: 'body-branch'
+        });
+
+      expect(mockService.generateArchitectureDiagram).toHaveBeenCalledWith({
+        repoUrl: 'https://github.com/body/repo',
+        branch: 'body-branch'
+      });
+    });
+
+    test('should fallback to query parameters if body is empty', async () => {
+      await request(app)
+        .post('/api/architecture')
+        .query({
+          repoUrl: 'https://github.com/query/repo',
+          branch: 'query-branch'
+        })
+        .send({});
+
+      expect(mockService.generateArchitectureDiagram).toHaveBeenCalledWith({
+        repoUrl: 'https://github.com/query/repo',
+        branch: 'query-branch'
+      });
+    });
+  });
+
+  describe('Response Format', () => {
+    test('should return only diagram and metadata in response', async () => {
+      const response = await request(app)
+        .post('/api/architecture')
+        .send({
+          repoUrl: 'https://github.com/test/repo'
+        });
+
+      expect(response.body).toHaveProperty('success');
+      expect(response.body).toHaveProperty('diagram');
+      expect(response.body).toHaveProperty('metadata');
+      expect(response.body).not.toHaveProperty('rawLlmResponse');
+      expect(response.body).not.toHaveProperty('prompt');
+      expect(response.body).not.toHaveProperty('systemPrompt');
+    });
+
+    test('should have correct Content-Type header', async () => {
+      const response = await request(app)
+        .post('/api/architecture')
+        .send({
+          repoUrl: 'https://github.com/test/repo'
+        });
+
+      expect(response.headers['content-type']).toMatch(/application\/json/);
+    });
+  });
+
+  describe('Error Logging', () => {
+    let consoleErrorSpy;
+
+    beforeEach(() => {
+      consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      consoleErrorSpy.mockRestore();
+    });
+
+    test('should log errors to console', async () => {
+      mockService.generateArchitectureDiagram.mockRejectedValue(
+        new Error('Test error')
+      );
+
+      await request(app)
+        .post('/api/architecture')
+        .send({
+          repoUrl: 'https://github.com/test/repo'
+        });
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        'Error generating architecture diagram:',
+        'Test error'
+      );
+    });
+  });
+});
+

--- a/backend/tests/architectureService.test.js
+++ b/backend/tests/architectureService.test.js
@@ -1,0 +1,265 @@
+import { jest } from '@jest/globals';
+import { createArchitectureService, UserInputError } from '../src/services/architectureService.js';
+import repoMetadataService from '../src/services/repoMetadataService.js';
+import llmService from '../src/services/llmService.js';
+
+// Mock the dependencies
+jest.mock('../src/services/repoMetadataService.js');
+jest.mock('../src/services/llmService.js');
+
+describe('Architecture Service', () => {
+  let architectureService;
+
+  const mockMetadata = {
+    owner: 'test',
+    repo: 'repo',
+    repoUrl: 'https://github.com/test/repo',
+    branch: 'main',
+    defaultBranch: 'main',
+    latestCommit: { sha: 'abc123' },
+    branches: { preview: ['main'], total: 1 },
+    fileTree: { text: 'src/\n  index.js' },
+    readme: '# Test',
+    generatedAt: '2025-01-01T00:00:00Z'
+  };
+
+  const mockLlmResult = {
+    diagram: 'graph TD\nA-->B',
+    provider: 'openai',
+    rawResponse: {},
+    usage: { total_tokens: 100 },
+    prompt: 'test prompt',
+    systemPrompt: 'test system prompt'
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    
+    // Setup mock functions
+    repoMetadataService.fetchRepoMetadata = jest.fn().mockResolvedValue(mockMetadata);
+    llmService.generateArchitectureDiagram = jest.fn().mockResolvedValue(mockLlmResult);
+    
+    // Create a fresh instance for each test
+    architectureService = createArchitectureService({
+      metadataService: repoMetadataService,
+      llm: llmService
+    });
+  });
+
+  describe('Input Validation', () => {
+    test('should throw UserInputError if repoUrl is missing', async () => {
+      await expect(
+        architectureService.generateArchitectureDiagram({})
+      ).rejects.toThrow(UserInputError);
+
+      await expect(
+        architectureService.generateArchitectureDiagram({})
+      ).rejects.toThrow('The "repoUrl" field is required');
+    });
+
+    test('should throw UserInputError if repoUrl is null', async () => {
+      await expect(
+        architectureService.generateArchitectureDiagram({ repoUrl: null })
+      ).rejects.toThrow(UserInputError);
+    });
+
+    test('should throw UserInputError if repoUrl is empty string', async () => {
+      await expect(
+        architectureService.generateArchitectureDiagram({ repoUrl: '' })
+      ).rejects.toThrow(UserInputError);
+    });
+
+    test('should throw UserInputError if repoUrl is whitespace only', async () => {
+      await expect(
+        architectureService.generateArchitectureDiagram({ repoUrl: '   ' })
+      ).rejects.toThrow(UserInputError);
+    });
+
+    test('should throw UserInputError if repoUrl is not a string', async () => {
+      await expect(
+        architectureService.generateArchitectureDiagram({ repoUrl: 123 })
+      ).rejects.toThrow(UserInputError);
+    });
+  });
+
+  describe('Successful Diagram Generation', () => {
+    test('should generate architecture diagram with valid repoUrl', async () => {
+      const result = await architectureService.generateArchitectureDiagram({
+        repoUrl: 'https://github.com/test/repo'
+      });
+
+      expect(result).toHaveProperty('diagram', 'graph TD\nA-->B');
+      expect(result).toHaveProperty('metadata');
+      expect(result.metadata).toHaveProperty('llm');
+      expect(result.metadata.llm.provider).toBe('openai');
+    });
+
+    test('should pass repoUrl to metadata service', async () => {
+      await architectureService.generateArchitectureDiagram({
+        repoUrl: 'https://github.com/facebook/react'
+      });
+
+      expect(repoMetadataService.fetchRepoMetadata).toHaveBeenCalledWith({
+        githubUrl: 'https://github.com/facebook/react',
+        branch: undefined
+      });
+    });
+
+    test('should pass branch parameter to metadata service', async () => {
+      await architectureService.generateArchitectureDiagram({
+        repoUrl: 'https://github.com/test/repo',
+        branch: 'develop'
+      });
+
+      expect(repoMetadataService.fetchRepoMetadata).toHaveBeenCalledWith({
+        githubUrl: 'https://github.com/test/repo',
+        branch: 'develop'
+      });
+    });
+
+    test('should pass metadata to LLM service', async () => {
+      await architectureService.generateArchitectureDiagram({
+        repoUrl: 'https://github.com/test/repo'
+      });
+
+      expect(llmService.generateArchitectureDiagram).toHaveBeenCalledWith(mockMetadata);
+    });
+
+    test('should return complete result with all fields', async () => {
+      const result = await architectureService.generateArchitectureDiagram({
+        repoUrl: 'https://github.com/test/repo'
+      });
+
+      expect(result).toHaveProperty('diagram');
+      expect(result).toHaveProperty('metadata');
+      expect(result).toHaveProperty('rawLlmResponse');
+      expect(result).toHaveProperty('prompt');
+      expect(result).toHaveProperty('systemPrompt');
+    });
+
+    test('should merge metadata with LLM provider info', async () => {
+      const result = await architectureService.generateArchitectureDiagram({
+        repoUrl: 'https://github.com/test/repo'
+      });
+
+      expect(result.metadata).toEqual({
+        ...mockMetadata,
+        llm: {
+          provider: 'openai'
+        }
+      });
+    });
+  });
+
+  describe('Error Handling', () => {
+    test('should propagate metadata service errors', async () => {
+      const metadataError = new Error('Failed to fetch metadata');
+      repoMetadataService.fetchRepoMetadata.mockRejectedValue(metadataError);
+
+      await expect(
+        architectureService.generateArchitectureDiagram({
+          repoUrl: 'https://github.com/test/repo'
+        })
+      ).rejects.toThrow('Failed to fetch metadata');
+    });
+
+    test('should propagate LLM service errors', async () => {
+      const llmError = new Error('LLM API failed');
+      llmService.generateArchitectureDiagram.mockRejectedValue(llmError);
+
+      await expect(
+        architectureService.generateArchitectureDiagram({
+          repoUrl: 'https://github.com/test/repo'
+        })
+      ).rejects.toThrow('LLM API failed');
+    });
+
+    test('should handle 404 repository errors', async () => {
+      const notFoundError = new Error('Repository not found');
+      notFoundError.statusCode = 404;
+      repoMetadataService.fetchRepoMetadata.mockRejectedValue(notFoundError);
+
+      await expect(
+        architectureService.generateArchitectureDiagram({
+          repoUrl: 'https://github.com/test/nonexistent'
+        })
+      ).rejects.toThrow('Repository not found');
+    });
+  });
+
+  describe('Service Factory', () => {
+    test('should create service with custom dependencies', () => {
+      const customMetadataService = {
+        fetchRepoMetadata: jest.fn().mockResolvedValue(mockMetadata)
+      };
+      const customLlmService = {
+        generateArchitectureDiagram: jest.fn().mockResolvedValue(mockLlmResult)
+      };
+
+      const customService = createArchitectureService({
+        metadataService: customMetadataService,
+        llm: customLlmService
+      });
+
+      expect(customService).toHaveProperty('generateArchitectureDiagram');
+      expect(customService).toHaveProperty('parseGithubUrl');
+    });
+
+    test('should use custom metadata service when provided', async () => {
+      const customMetadataService = {
+        fetchRepoMetadata: jest.fn().mockResolvedValue(mockMetadata)
+      };
+
+      const customService = createArchitectureService({
+        metadataService: customMetadataService,
+        llm: llmService
+      });
+
+      await customService.generateArchitectureDiagram({
+        repoUrl: 'https://github.com/test/repo'
+      });
+
+      expect(customMetadataService.fetchRepoMetadata).toHaveBeenCalled();
+    });
+
+    test('should use custom LLM service when provided', async () => {
+      const customLlmService = {
+        generateArchitectureDiagram: jest.fn().mockResolvedValue(mockLlmResult)
+      };
+
+      const customService = createArchitectureService({
+        metadataService: repoMetadataService,
+        llm: customLlmService
+      });
+
+      await customService.generateArchitectureDiagram({
+        repoUrl: 'https://github.com/test/repo'
+      });
+
+      expect(customLlmService.generateArchitectureDiagram).toHaveBeenCalled();
+    });
+  });
+
+  describe('UserInputError', () => {
+    test('should be an Error instance', () => {
+      const error = new UserInputError('Test error');
+      expect(error).toBeInstanceOf(Error);
+    });
+
+    test('should have correct name', () => {
+      const error = new UserInputError('Test error');
+      expect(error.name).toBe('UserInputError');
+    });
+
+    test('should have statusCode 400', () => {
+      const error = new UserInputError('Test error');
+      expect(error.statusCode).toBe(400);
+    });
+
+    test('should preserve error message', () => {
+      const error = new UserInputError('Custom message');
+      expect(error.message).toBe('Custom message');
+    });
+  });
+});
+

--- a/backend/tests/llmService.test.js
+++ b/backend/tests/llmService.test.js
@@ -1,6 +1,7 @@
 import { jest } from '@jest/globals';
 import llmService from '../src/services/llmService.js';
 import repoMetadataService from '../src/services/repoMetadataService.js';
+import { LlmProviderError } from '../src/services/llmService.js';
 
 global.fetch = jest.fn();
 
@@ -15,46 +16,310 @@ describe('LLM Service', () => {
     process.env.LLM_PROVIDER = 'huggingface';
     process.env.LLM_API_KEY = 'mock_key';
     process.env.LLM_API_URL = 'https://api.openai.com';
-    
-    process.env.LLM_MODEL = 'test-model-v1'; 
+    process.env.LLM_MODEL = 'test-model-v1';
+    process.env.LLM_MAX_NEW_TOKENS = '1024';
   });
 
   afterAll(() => {
     process.env = originalEnv;
   });
 
-  test('should throw error if metadata is missing', async () => {
-    await expect(llmService.generateArchitectureDiagram(null))
-      .rejects.toThrow('Repository metadata is required');
-  });
-
-  test('HuggingFace: handles array response and fallback URL', async () => {
-    process.env.LLM_PROVIDER = 'huggingface';
-    
-    delete process.env.LLM_API_URL;
-    
-    global.fetch.mockResolvedValue({
-      ok: true,
-      text: async () => JSON.stringify([{ generated_text: 'graph TD\nX-->Y' }])
+  describe('Input Validation', () => {
+    test('should throw error if metadata is missing', async () => {
+      await expect(llmService.generateArchitectureDiagram(null))
+        .rejects.toThrow('Repository metadata is required');
     });
 
-    const res = await llmService.generateArchitectureDiagram({});
-    
-    expect(res.diagram).toBe('graph TD\nX-->Y');
-    expect(global.fetch.mock.calls[0][0]).toContain('router.huggingface.co/hf-inference/models/test-model-v1');
+    test('should throw error if metadata is undefined', async () => {
+      await expect(llmService.generateArchitectureDiagram(undefined))
+        .rejects.toThrow('Repository metadata is required');
+    });
   });
 
-  test('OpenAI: Extract response correctly', async () => {
-    process.env.LLM_PROVIDER = 'openai';
-    
-    global.fetch.mockResolvedValue({
-      ok: true,
-      text: async () => JSON.stringify({
-        choices: [{ message: { content: 'Here: ```mermaid\ngraph A\n```' } }]
-      })
+  describe('HuggingFace Provider', () => {
+    beforeEach(() => {
+      process.env.LLM_PROVIDER = 'huggingface';
     });
-    
-    const res = await llmService.generateArchitectureDiagram({});
-    expect(res.diagram).toBe('graph A');
+
+    test('should throw error if API URL and MODEL are missing', async () => {
+      delete process.env.LLM_API_URL;
+      delete process.env.LLM_MODEL;
+      
+      await expect(llmService.generateArchitectureDiagram({}))
+        .rejects.toThrow('LLM_API_URL or LLM_MODEL must be configured');
+    });
+
+    test('should throw error if API key is missing', async () => {
+      delete process.env.LLM_API_KEY;
+      delete process.env.HF_TOKEN;
+      
+      await expect(llmService.generateArchitectureDiagram({}))
+        .rejects.toThrow('LLM_API_KEY (or HF_TOKEN) is required');
+    });
+
+    test('should use HF_TOKEN as fallback for API key', async () => {
+      delete process.env.LLM_API_KEY;
+      process.env.HF_TOKEN = 'hf_token_fallback';
+      
+      global.fetch.mockResolvedValue({
+        ok: true,
+        text: async () => JSON.stringify([{ generated_text: 'graph TD\nA-->B' }])
+      });
+
+      await llmService.generateArchitectureDiagram({});
+      
+      const fetchCall = global.fetch.mock.calls[0];
+      expect(fetchCall[1].headers.Authorization).toBe('Bearer hf_token_fallback');
+    });
+
+    test('should handle array response format', async () => {
+      delete process.env.LLM_API_URL;
+      
+      global.fetch.mockResolvedValue({
+        ok: true,
+        text: async () => JSON.stringify([{ generated_text: 'graph TD\nX-->Y' }])
+      });
+
+      const res = await llmService.generateArchitectureDiagram({});
+      
+      expect(res.diagram).toBe('graph TD\nX-->Y');
+      expect(global.fetch.mock.calls[0][0]).toContain('router.huggingface.co/hf-inference/models/test-model-v1');
+    });
+
+    test('should handle object response format', async () => {
+      global.fetch.mockResolvedValue({
+        ok: true,
+        text: async () => JSON.stringify({ generated_text: 'graph LR\nA-->B' })
+      });
+
+      const res = await llmService.generateArchitectureDiagram({});
+      expect(res.diagram).toBe('graph LR\nA-->B');
+    });
+
+    test('should handle HTTP error responses', async () => {
+      global.fetch.mockResolvedValue({
+        ok: false,
+        status: 503,
+        text: async () => 'Service Unavailable'
+      });
+
+      await expect(llmService.generateArchitectureDiagram({}))
+        .rejects.toThrow('HuggingFace request failed with 503');
+    });
+
+    test('should handle unparseable JSON response', async () => {
+      global.fetch.mockResolvedValue({
+        ok: true,
+        text: async () => 'not valid json'
+      });
+
+      await expect(llmService.generateArchitectureDiagram({}))
+        .rejects.toThrow('Unable to parse HuggingFace response');
+    });
+  });
+
+  describe('OpenAI Provider', () => {
+    beforeEach(() => {
+      process.env.LLM_PROVIDER = 'openai';
+    });
+
+    test('should throw error if API URL is missing', async () => {
+      delete process.env.LLM_API_URL;
+      
+      await expect(llmService.generateArchitectureDiagram({}))
+        .rejects.toThrow('LLM_API_URL, LLM_API_KEY, and LLM_MODEL must be set');
+    });
+
+    test('should throw error if API key is missing', async () => {
+      delete process.env.LLM_API_KEY;
+      
+      await expect(llmService.generateArchitectureDiagram({}))
+        .rejects.toThrow('LLM_API_URL, LLM_API_KEY, and LLM_MODEL must be set');
+    });
+
+    test('should throw error if model is missing', async () => {
+      delete process.env.LLM_MODEL;
+      
+      await expect(llmService.generateArchitectureDiagram({}))
+        .rejects.toThrow('LLM_API_URL, LLM_API_KEY, and LLM_MODEL must be set');
+    });
+
+    test('should extract response with mermaid code block', async () => {
+      global.fetch.mockResolvedValue({
+        ok: true,
+        text: async () => JSON.stringify({
+          choices: [{ message: { content: 'Here: ```mermaid\ngraph A\n```' } }]
+        })
+      });
+      
+      const res = await llmService.generateArchitectureDiagram({});
+      expect(res.diagram).toBe('graph A');
+    });
+
+    test('should extract response with generic code block', async () => {
+      global.fetch.mockResolvedValue({
+        ok: true,
+        text: async () => JSON.stringify({
+          choices: [{ message: { content: '```\ngraph TD\nA-->B\n```' } }]
+        })
+      });
+      
+      const res = await llmService.generateArchitectureDiagram({});
+      expect(res.diagram).toBe('graph TD\nA-->B');
+    });
+
+    test('should extract response starting with graph keyword', async () => {
+      global.fetch.mockResolvedValue({
+        ok: true,
+        text: async () => JSON.stringify({
+          choices: [{ message: { content: 'graph LR\nA-->B' } }]
+        })
+      });
+      
+      const res = await llmService.generateArchitectureDiagram({});
+      expect(res.diagram).toBe('graph LR\nA-->B');
+    });
+
+    test('should handle HTTP error responses', async () => {
+      global.fetch.mockResolvedValue({
+        ok: false,
+        status: 401,
+        text: async () => 'Unauthorized'
+      });
+
+      await expect(llmService.generateArchitectureDiagram({}))
+        .rejects.toThrow('OpenAI-compatible request failed with 401');
+    });
+
+    test('should handle unparseable JSON response', async () => {
+      global.fetch.mockResolvedValue({
+        ok: true,
+        text: async () => 'invalid json'
+      });
+
+      await expect(llmService.generateArchitectureDiagram({}))
+        .rejects.toThrow('Unable to parse OpenAI-compatible response');
+    });
+
+    test('should include usage information when available', async () => {
+      global.fetch.mockResolvedValue({
+        ok: true,
+        text: async () => JSON.stringify({
+          choices: [{ message: { content: 'graph TD\nA-->B' } }],
+          usage: { prompt_tokens: 100, completion_tokens: 50, total_tokens: 150 }
+        })
+      });
+      
+      const res = await llmService.generateArchitectureDiagram({});
+      expect(res.usage).toEqual({
+        prompt_tokens: 100,
+        completion_tokens: 50,
+        total_tokens: 150
+      });
+    });
+  });
+
+  describe('Diagram Extraction', () => {
+    beforeEach(() => {
+      process.env.LLM_PROVIDER = 'openai';
+    });
+
+    test('should throw error if response contains no Mermaid diagram', async () => {
+      global.fetch.mockResolvedValue({
+        ok: true,
+        text: async () => JSON.stringify({
+          choices: [{ message: { content: 'Just some text without a diagram' } }]
+        })
+      });
+
+      await expect(llmService.generateArchitectureDiagram({}))
+        .rejects.toThrow('LLM response did not include a Mermaid diagram');
+    });
+
+    test('should extract diagram from mermaid tags', async () => {
+      global.fetch.mockResolvedValue({
+        ok: true,
+        text: async () => JSON.stringify({
+          choices: [{ message: { content: '<mermaid>graph TD\nA-->B</mermaid>' } }]
+        })
+      });
+
+      const res = await llmService.generateArchitectureDiagram({});
+      expect(res.diagram).toBe('graph TD\nA-->B');
+    });
+  });
+
+  describe('System Prompt', () => {
+    beforeEach(() => {
+      process.env.LLM_PROVIDER = 'openai';
+    });
+
+    test('should use custom system prompt from options', async () => {
+      global.fetch.mockResolvedValue({
+        ok: true,
+        text: async () => JSON.stringify({
+          choices: [{ message: { content: 'graph TD\nA-->B' } }]
+        })
+      });
+
+      const customPrompt = 'Custom system prompt for testing';
+      const res = await llmService.generateArchitectureDiagram({}, { systemPrompt: customPrompt });
+      
+      expect(res.systemPrompt).toBe(customPrompt);
+    });
+
+    test('should use environment variable for system prompt', async () => {
+      process.env.LLM_SYSTEM_PROMPT = 'Environment system prompt';
+      
+      global.fetch.mockResolvedValue({
+        ok: true,
+        text: async () => JSON.stringify({
+          choices: [{ message: { content: 'graph TD\nA-->B' } }]
+        })
+      });
+
+      const res = await llmService.generateArchitectureDiagram({});
+      expect(res.systemPrompt).toBe('Environment system prompt');
+    });
+
+    test('should use default system prompt if none provided', async () => {
+      delete process.env.LLM_SYSTEM_PROMPT;
+      
+      global.fetch.mockResolvedValue({
+        ok: true,
+        text: async () => JSON.stringify({
+          choices: [{ message: { content: 'graph TD\nA-->B' } }]
+        })
+      });
+
+      const res = await llmService.generateArchitectureDiagram({});
+      expect(res.systemPrompt).toContain('expert software architect');
+    });
+  });
+
+  describe('Return Values', () => {
+    beforeEach(() => {
+      process.env.LLM_PROVIDER = 'openai';
+    });
+
+    test('should return complete result object', async () => {
+      global.fetch.mockResolvedValue({
+        ok: true,
+        text: async () => JSON.stringify({
+          choices: [{ message: { content: 'graph TD\nA-->B' } }],
+          usage: { total_tokens: 100 }
+        })
+      });
+
+      const res = await llmService.generateArchitectureDiagram({ test: 'metadata' });
+      
+      expect(res).toHaveProperty('diagram');
+      expect(res).toHaveProperty('provider');
+      expect(res).toHaveProperty('rawResponse');
+      expect(res).toHaveProperty('usage');
+      expect(res).toHaveProperty('prompt');
+      expect(res).toHaveProperty('systemPrompt');
+      expect(res.provider).toBe('openai');
+    });
   });
 });

--- a/backend/tests/repoMetadataService.test.js
+++ b/backend/tests/repoMetadataService.test.js
@@ -1,0 +1,287 @@
+import { jest } from '@jest/globals';
+import repoMetadataService, {
+  parseGithubUrl,
+  fetchRepoMetadata,
+  formatMetadataForPrompt,
+  RepoMetadataError
+} from '../src/services/repoMetadataService.js';
+import githubService from '../src/services/githubService.js';
+
+// Mock githubService
+jest.mock('../src/services/githubService.js');
+
+describe('Repo Metadata Service', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    
+    // Setup default mocks
+    githubService.getAllBranches = jest.fn();
+    githubService.getDefaultBranch = jest.fn();
+    githubService.getRepoTree = jest.fn();
+    githubService.getLatestCommit = jest.fn();
+    githubService.getFile = jest.fn();
+  });
+
+  describe('parseGithubUrl', () => {
+    test('should parse HTTPS GitHub URL', () => {
+      const result = parseGithubUrl('https://github.com/facebook/react');
+      expect(result).toEqual({ owner: 'facebook', repo: 'react' });
+    });
+
+    test('should parse HTTPS GitHub URL with .git extension', () => {
+      const result = parseGithubUrl('https://github.com/expressjs/express.git');
+      expect(result).toEqual({ owner: 'expressjs', repo: 'express' });
+    });
+
+    test('should parse SSH GitHub URL', () => {
+      const result = parseGithubUrl('git@github.com:torvalds/linux.git');
+      expect(result).toEqual({ owner: 'torvalds', repo: 'linux' });
+    });
+
+    test('should parse SSH GitHub URL without .git', () => {
+      const result = parseGithubUrl('git@github.com:nodejs/node');
+      expect(result).toEqual({ owner: 'nodejs', repo: 'node' });
+    });
+
+    test('should handle URLs with hyphens and dots', () => {
+      const result = parseGithubUrl('https://github.com/my-org/my.repo-name');
+      expect(result).toEqual({ owner: 'my-org', repo: 'my.repo-name' });
+    });
+
+    test('should throw error for null URL', () => {
+      expect(() => parseGithubUrl(null)).toThrow('GitHub URL is required');
+    });
+
+    test('should throw error for undefined URL', () => {
+      expect(() => parseGithubUrl(undefined)).toThrow('GitHub URL is required');
+    });
+
+    test('should throw error for empty string', () => {
+      expect(() => parseGithubUrl('')).toThrow('GitHub URL is required');
+    });
+
+    test('should throw error for non-GitHub URL', () => {
+      expect(() => parseGithubUrl('https://gitlab.com/user/repo'))
+        .toThrow('Unable to parse GitHub URL');
+    });
+
+    test('should throw error for malformed URL', () => {
+      expect(() => parseGithubUrl('not-a-url'))
+        .toThrow('Unable to parse GitHub URL');
+    });
+  });
+
+  describe('fetchRepoMetadata', () => {
+    const mockBranches = ['main', 'develop', 'feature-1'];
+    const mockTree = [
+      { name: 'src', type: 'dir', children: [{ name: 'index.js', type: 'file' }] },
+      { name: 'README.md', type: 'file' }
+    ];
+    const mockCommit = {
+      sha: 'abc123',
+      message: 'Initial commit',
+      author: 'Test Author',
+      date: '2025-01-01T00:00:00Z'
+    };
+
+    beforeEach(() => {
+      githubService.getAllBranches.mockResolvedValue(mockBranches);
+      githubService.getDefaultBranch.mockResolvedValue('main');
+      githubService.getRepoTree.mockResolvedValue(mockTree);
+      githubService.getLatestCommit.mockResolvedValue(mockCommit);
+      githubService.getFile.mockResolvedValue('# Test README\nThis is a test.');
+    });
+
+    test('should fetch complete metadata for a repository', async () => {
+      const result = await fetchRepoMetadata({
+        githubUrl: 'https://github.com/test/repo',
+        branch: 'main'
+      });
+
+      expect(result).toHaveProperty('owner', 'test');
+      expect(result).toHaveProperty('repo', 'repo');
+      expect(result).toHaveProperty('repoUrl', 'https://github.com/test/repo');
+      expect(result).toHaveProperty('branch', 'main');
+      expect(result).toHaveProperty('defaultBranch', 'main');
+      expect(result).toHaveProperty('latestCommit', mockCommit);
+      expect(result).toHaveProperty('branches');
+      expect(result).toHaveProperty('fileTree');
+      expect(result).toHaveProperty('readme');
+      expect(result).toHaveProperty('generatedAt');
+    });
+
+    test('should use default branch when branch not specified', async () => {
+      const result = await fetchRepoMetadata({
+        githubUrl: 'https://github.com/test/repo'
+      });
+
+      expect(result.branch).toBe('main');
+      expect(githubService.getRepoTree).toHaveBeenCalledWith('test', 'repo', '', 'main');
+    });
+
+    test('should handle README not found', async () => {
+      githubService.getFile.mockRejectedValue(new Error('Not found'));
+
+      const result = await fetchRepoMetadata({
+        githubUrl: 'https://github.com/test/repo'
+      });
+
+      expect(result.readme).toBe('(README not found)');
+    });
+
+    test('should throw RepoMetadataError for 404 repository', async () => {
+      githubService.getAllBranches.mockRejectedValue({ status: 404 });
+
+      await expect(fetchRepoMetadata({
+        githubUrl: 'https://github.com/test/nonexistent'
+      })).rejects.toThrow('Repository or branch not found on GitHub');
+    });
+
+    test('should throw RepoMetadataError for GitHub service errors', async () => {
+      githubService.getAllBranches.mockRejectedValue(new Error('API Error'));
+
+      await expect(fetchRepoMetadata({
+        githubUrl: 'https://github.com/test/repo'
+      })).rejects.toThrow(RepoMetadataError);
+    });
+
+    test('should throw error for invalid GitHub URL', async () => {
+      await expect(fetchRepoMetadata({
+        githubUrl: 'invalid-url'
+      })).rejects.toThrow('Unable to parse GitHub URL');
+    });
+
+    test('should limit branches preview', async () => {
+      const manyBranches = Array.from({ length: 30 }, (_, i) => `branch-${i}`);
+      githubService.getAllBranches.mockResolvedValue(manyBranches);
+
+      const result = await fetchRepoMetadata({
+        githubUrl: 'https://github.com/test/repo'
+      });
+
+      expect(result.branches.preview.length).toBeLessThanOrEqual(20);
+      expect(result.branches.total).toBe(30);
+      expect(result.branches.note).toContain('+10 more');
+    });
+
+    test('should truncate large file trees', async () => {
+      const largeTree = Array.from({ length: 500 }, (_, i) => ({
+        name: `file-${i}.js`,
+        type: 'file'
+      }));
+      githubService.getRepoTree.mockResolvedValue(largeTree);
+
+      const result = await fetchRepoMetadata({
+        githubUrl: 'https://github.com/test/repo'
+      });
+
+      expect(result.fileTree.stats.truncated).toBe(true);
+    });
+
+    test('should truncate long README content', async () => {
+      const longReadme = 'A'.repeat(10000);
+      githubService.getFile.mockResolvedValue(longReadme);
+
+      const result = await fetchRepoMetadata({
+        githubUrl: 'https://github.com/test/repo'
+      });
+
+      expect(result.readme.length).toBeLessThan(longReadme.length);
+      expect(result.readme).toContain('truncated');
+    });
+  });
+
+  describe('formatMetadataForPrompt', () => {
+    const mockMetadata = {
+      owner: 'test',
+      repo: 'repo',
+      repoUrl: 'https://github.com/test/repo',
+      branch: 'main',
+      defaultBranch: 'main',
+      latestCommit: {
+        sha: 'abc123',
+        message: 'Test commit'
+      },
+      branches: {
+        preview: ['main', 'develop'],
+        total: 2,
+        note: ''
+      },
+      fileTree: {
+        text: 'repo/\n  src/\n    index.js',
+        stats: { files: 1, directories: 1 }
+      },
+      readme: '# Test README',
+      generatedAt: '2025-01-01T00:00:00Z'
+    };
+
+    test('should format metadata into a prompt string', () => {
+      const prompt = formatMetadataForPrompt(mockMetadata);
+
+      expect(prompt).toContain('Repository: test/repo');
+      expect(prompt).toContain('Source URL: https://github.com/test/repo');
+      expect(prompt).toContain('Analyzed branch: main');
+      expect(prompt).toContain('Latest commit:');
+      expect(prompt).toContain('Branches preview (2 total):');
+      expect(prompt).toContain('- main');
+      expect(prompt).toContain('- develop');
+      expect(prompt).toContain('File tree snapshot');
+      expect(prompt).toContain('README excerpt');
+    });
+
+    test('should handle missing branches gracefully', () => {
+      const metadata = { ...mockMetadata, branches: null };
+      const prompt = formatMetadataForPrompt(metadata);
+
+      expect(prompt).toContain('Branches preview (0 total)');
+      expect(prompt).toContain('(no branches found)');
+    });
+
+    test('should handle missing file tree gracefully', () => {
+      const metadata = { ...mockMetadata, fileTree: null };
+      const prompt = formatMetadataForPrompt(metadata);
+
+      expect(prompt).toContain('(file tree not available)');
+    });
+
+    test('should handle missing README gracefully', () => {
+      const metadata = { ...mockMetadata, readme: null };
+      const prompt = formatMetadataForPrompt(metadata);
+
+      expect(prompt).toContain('(README not available)');
+    });
+
+    test('should throw error for null metadata', () => {
+      expect(() => formatMetadataForPrompt(null))
+        .toThrow('Metadata payload is required');
+    });
+
+    test('should throw error for undefined metadata', () => {
+      expect(() => formatMetadataForPrompt(undefined))
+        .toThrow('Metadata payload is required');
+    });
+
+    test('should include branch note when present', () => {
+      const metadata = {
+        ...mockMetadata,
+        branches: {
+          preview: ['main'],
+          total: 10,
+          note: ' (+9 more)'
+        }
+      };
+      const prompt = formatMetadataForPrompt(metadata);
+
+      expect(prompt).toContain('(+9 more)');
+    });
+  });
+
+  describe('Service Export', () => {
+    test('should export all required functions', () => {
+      expect(repoMetadataService).toHaveProperty('fetchRepoMetadata');
+      expect(repoMetadataService).toHaveProperty('parseGithubUrl');
+      expect(repoMetadataService).toHaveProperty('formatMetadataForPrompt');
+    });
+  });
+});
+


### PR DESCRIPTION
… features.

<!-- Change the <branch> to your branch name (no <> tags) -->

![Coverage Badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/elaine-ch/950ea96d8c81479a2fc3e12d3ca71532/raw/Repository-Architecture-Diagramming__heads_main.json)

## Description

<!-- Provide a clear and concise description of what this PR does -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Other (please describe): Enhanced LLM-related feature testing besides the basic test cases.

## Related Issues

<!-- Link to related issues using #issue-number -->

Issue #<!-- issue number -->

## Changes Made

<!-- List the key changes made in this PR -->

- Add input validation and llm provider etc. test in `llmService.test.js`.
- Add metadata test for github repo in `repoMetadataService.test.js`.
- Add service-layer test in `architectureService.test.js`.
- Add API route test in `architectureAPI.test.js`.

## Testing

<!-- Describe the tests you ran and how to verify your changes -->

- [x] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

```bash
cd backend && export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" && npm test 2>&1 | tail -50
```

```
         |               ^
      28 |       const statusCode = error.statusCode || (error instanceof UserInputError ? 400 : 500);
      29 |       return res.status(statusCode).json({
      30 |         success: false,

      at error (src/routes/architectureAPI.js:27:15)

    console.error
      Error generating architecture diagram: Service error

      25 |       });
      26 |     } catch (error) {
    > 27 |       console.error('Error generating architecture diagram:', error.message);
         |               ^
      28 |       const statusCode = error.statusCode || (error instanceof UserInputError ? 400 : 500);
      29 |       return res.status(statusCode).json({
      30 |         success: false,

      at error (src/routes/architectureAPI.js:27:15)

PASS tests/githubService.test.js
  ● Console

    console.log
      [dotenv@17.2.3] injecting env (0) from .env -- tip: ⚙️  load multiple .env files with { path: ['.env.local', '.env'] }

      at _log (node_modules/dotenv/lib/main.js:142:11)

-------------------------|---------|----------|---------|---------|---------------------------------------
File                     | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s                     
-------------------------|---------|----------|---------|---------|---------------------------------------
All files                |   90.94 |       75 |   97.43 |   93.87 |                                       
 config                  |   71.42 |       50 |     100 |     100 |                                       
  parserConfig.js        |   71.42 |       50 |     100 |     100 | 142-145                               
 routes                  |     100 |     90.9 |     100 |     100 |                                       
  architectureAPI.js     |     100 |     90.9 |     100 |     100 | 28                                    
 services                |   91.22 |    75.06 |   97.33 |   93.56 |                                       
  architectureService.js |     100 |      100 |     100 |     100 |                                       
  dependencyService.js   |    90.5 |    75.22 |     100 |   93.24 | 74-75,100,205,232,260,335,354-355,401 
  githubService.js       |   83.54 |    58.69 |   85.71 |   85.33 | 30-33,35-41,104-106,120,184           
  graphService.js        |      94 |    79.26 |     100 |    97.7 | 145,150                               
  llmService.js          |   91.46 |    76.78 |     100 |   91.46 | 56,66-72,143                          
  repoMetadataService.js |   95.23 |    76.47 |     100 |   98.75 | 180                                   
-------------------------|---------|----------|---------|---------|---------------------------------------

Test Suites: 7 passed, 7 total
Tests:       112 passed, 112 total
Snapshots:   0 total
Time:        3.405 s
Ran all test suites.
```

## Checklist

<!-- Mark completed items with an "x" -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

<!-- Add any additional notes or context for reviewers -->
